### PR TITLE
[build] add setup.py for readysetdata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include requirements.txt
+include scripts/*

--- a/README.md
+++ b/README.md
@@ -16,7 +16,18 @@ Requires Python 3.8+.
 
     git clone https://github.com/saulpw/readysetdata.git
     cd readysetdata
-    make setup  # install dependencies via pip
+
+Then from within the repository,
+
+    make setup
+
+or
+
+    pip install .
+
+or
+
+    python3 setup.py install
 
 # Datasets
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier:
+
+from setuptools import setup
+
+
+def readme():
+    with open("README.md") as f:
+        return f.read()
+
+def requirements():
+    with open("requirements.txt") as f:
+        return f.read().split("\n")
+
+
+setup(
+        name="readysetdata",
+        version="",
+        description="A collection of tools to convert select datasets into ready-to-use formats.",
+        long_description=readme(),
+        long_description_content_type="text/markdown",
+        classifiers=[
+            "Development Status :: 4 - Beta",
+            "Programming Language :: Python ::3",
+        ],
+        keywords="datasets readysetdata",
+        author="Saul Pwanson",
+        url="https://github.com/saulpw/readysetdata",
+        python_requires=">=3.8",
+        py_modules=["readysetdata"],
+        packages=["readysetdata"],
+        #scripts=["scripts/remote-unzip.py"],
+        install_requires=requirements(),
+)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
         python_requires=">=3.8",
         py_modules=["readysetdata"],
         packages=["readysetdata"],
-        #scripts=["scripts/remote-unzip.py"],
+        scripts=["scripts/remote-unzip.py"],
         install_requires=requirements(),
 )


### PR DESCRIPTION
This is a very basic `setup.py`. It just installs `readysetdata` as a python library and makes sure it has everything it needs if it ended up being pushed to `PyPI`.

I can add any of the `scripts` as executables as part of the installation process. Do we want that?

**Edit**: I added `remote-unzip.py` as an example line for what adding a script looks like (and because I wanted it :)). We can add any other scripts as we see fit by extending that `scripts=[]` list in `setup.py`. The `MANIFEST.in` bundles them all already, so it will not need to be extended.