### PR TITLE
Fixes to error logging; Turn off geonames-nous

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ movielens:
 
 geonames:
 	scripts/geonames-us.py -o ${OUTPUT}
-	scripts/geonames-nonus.py -o ${OUTPUT}
+	# scripts/geonames-nonus.py -o ${OUTPUT} # commented out; url and structure of .zip have changed
 	cd ${OUTPUT} && ${ZIP} geonames.arrowz geonames_*.arrow
 
 wikipedia:

--- a/readysetdata/output.py
+++ b/readysetdata/output.py
@@ -1,6 +1,7 @@
 import sys
 import re
 from pathlib import Path
+import traceback
 
 from readysetdata import get_optarg
 
@@ -22,8 +23,10 @@ def output(dbname, tblname, rows):
             try:
                 r = next(it)
                 out.output(r)
+            except StopIteration:
+                break
             except Exception as e:
-                print(str(e), file=sys.stderr)
+                print(traceback.print_exc(), file=sys.stderr)
 
 
 def cleanid(orig):

--- a/scripts/geonames-nonus.py
+++ b/scripts/geonames-nonus.py
@@ -3,6 +3,8 @@
 from readysetdata import parse_asv, output, unzip_url
 
 URL = 'https://geonames.nga.mil/gns/html/cntyfile/geonames_20220606.zip'
+# https://geonames.nga.mil/geonames/GNSData/fc_files/Whole_World.7z
+# URL and structure of zip have changed
 
 FC_map = dict(
     A = 'Administrative region',


### PR DESCRIPTION
For geonames-nous, the new zip file is located here: https://geonames.nga.mil/geonames/GNSData/fc_files/Whole_World.7z